### PR TITLE
Publish urls

### DIFF
--- a/app/Blueprint/Healthcheck/EventListener/HealthcheckServiceWriterListener.php
+++ b/app/Blueprint/Healthcheck/EventListener/HealthcheckServiceWriterListener.php
@@ -2,7 +2,7 @@
 
 use Rancherize\Blueprint\Healthcheck\HealthcheckExtraInformation\HealthcheckExtraInformation;
 use Rancherize\Blueprint\Healthcheck\HealthcheckYamlWriter\HealthcheckYamlWriter;
-use Rancherize\Blueprint\Infrastructure\Service\Events\ServiceWriterRancherServicePreparedEvent;
+use Rancherize\Blueprint\Infrastructure\Service\Events\ServiceWriterServicePreparedEvent;
 use Rancherize\Blueprint\Infrastructure\Service\ExtraInformationNotFoundException;
 
 /**
@@ -24,9 +24,9 @@ class HealthcheckServiceWriterListener {
 	}
 
 	/**
-	 * @param ServiceWriterRancherServicePreparedEvent $event
+	 * @param ServiceWriterServicePreparedEvent $event
 	 */
-	public function rancherServicePrepared( ServiceWriterRancherServicePreparedEvent $event ) {
+	public function servicePrepared( ServiceWriterServicePreparedEvent $event ) {
 		$rancherData = $event->getRancherContent();
 
 		$fileVersion = $event->getFileVersion();

--- a/app/Blueprint/Healthcheck/HealthcheckProvider.php
+++ b/app/Blueprint/Healthcheck/HealthcheckProvider.php
@@ -4,7 +4,7 @@ use Rancherize\Blueprint\Healthcheck\EventListener\HealthcheckServiceWriterListe
 use Rancherize\Blueprint\Healthcheck\HealthcheckConfigurationToService\HealthcheckConfigurationToService;
 use Rancherize\Blueprint\Healthcheck\HealthcheckExtraInformation\HealthcheckDefaultInformationSetter;
 use Rancherize\Blueprint\Healthcheck\HealthcheckYamlWriter\HealthcheckYamlWriter;
-use Rancherize\Blueprint\Infrastructure\Service\Events\ServiceWriterRancherServicePreparedEvent;
+use Rancherize\Blueprint\Infrastructure\Service\Events\ServiceWriterServicePreparedEvent;
 use Rancherize\Plugin\Provider;
 use Rancherize\Plugin\ProviderTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -42,6 +42,6 @@ class HealthcheckProvider implements Provider {
 		 */
 		$event = $this->container['event'];
 		$listener = $this->container['healthcheck-service-writer-listener'];
-		$event->addListener(ServiceWriterRancherServicePreparedEvent::NAME, [$listener, 'rancherServicePrepared']);
+		$event->addListener(ServiceWriterServicePreparedEvent::NAME, [$listener, 'servicePrepared']);
 	}
 }

--- a/app/Blueprint/Infrastructure/Service/Events/ServiceWriterServicePreparedEvent.php
+++ b/app/Blueprint/Infrastructure/Service/Events/ServiceWriterServicePreparedEvent.php
@@ -35,15 +35,20 @@ class ServiceWriterServicePreparedEvent extends Event {
 	 * @var int
 	 */
 	private $fileVersion = 2;
+	/**
 
 	/**
 	 * ServiceWriterServicePreparedEvent constructor.
 	 * @param Service $service
+	 * @param $dockerContent
+	 * @param $volumes
 	 * @param $rancherContent
 	 */
-	public function __construct( Service $service, &$rancherContent) {
+	public function __construct( Service $service, $dockerContent, $volumes, $rancherContent) {
 		$this->service = $service;
 		$this->rancherContent = $rancherContent;
+		$this->dockerContent = $dockerContent;
+		$this->volumeDefinition = $volumes;
 	}
 
 	/**

--- a/app/Blueprint/Infrastructure/Service/Events/ServiceWriterServicePreparedEvent.php
+++ b/app/Blueprint/Infrastructure/Service/Events/ServiceWriterServicePreparedEvent.php
@@ -4,16 +4,22 @@ use Rancherize\Blueprint\Infrastructure\Service\Service;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class ServiceWriterRancherServicePreparedEvent
+ * Class ServiceWriterServicePreparedEvent
  * @package Rancherize\Blueprint\Infrastructure\Service\Events
  */
-class ServiceWriterRancherServicePreparedEvent extends Event {
+class ServiceWriterServicePreparedEvent extends Event {
 
 	const NAME = 'service-writer.write';
+
 	/**
 	 * @var Service
 	 */
 	private $service;
+
+	/**
+	 * @var array
+	 */
+	private $dockerContent;
 
 	/**
 	 * @var
@@ -21,12 +27,17 @@ class ServiceWriterRancherServicePreparedEvent extends Event {
 	private $rancherContent;
 
 	/**
+	 * @var array
+	 */
+	private $volumeDefinition;
+
+	/**
 	 * @var int
 	 */
 	private $fileVersion = 2;
 
 	/**
-	 * ServiceWriterRancherServicePreparedEvent constructor.
+	 * ServiceWriterServicePreparedEvent constructor.
 	 * @param Service $service
 	 * @param $rancherContent
 	 */
@@ -61,6 +72,34 @@ class ServiceWriterRancherServicePreparedEvent extends Event {
 	 */
 	public function getFileVersion() {
 		return $this->fileVersion;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getDockerContent() {
+		return $this->dockerContent;
+	}
+
+	/**
+	 * @param array $dockerContent
+	 */
+	public function setDockerContent( array $dockerContent ) {
+		$this->dockerContent = $dockerContent;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getVolumeDefinition() {
+		return $this->volumeDefinition;
+	}
+
+	/**
+	 * @param array $volumeDefinition
+	 */
+	public function setVolumeDefinition( array $volumeDefinition ) {
+		$this->volumeDefinition = $volumeDefinition;
 	}
 
 }

--- a/app/Blueprint/PublishUrls/EventListener/PublishUrlsServiceWriterListener.php
+++ b/app/Blueprint/PublishUrls/EventListener/PublishUrlsServiceWriterListener.php
@@ -26,7 +26,7 @@ class PublishUrlsServiceWriterListener {
 	/**
 	 * @param ServiceWriterServicePreparedEvent $event
 	 */
-	public function dockerServicePrepared( ServiceWriterServicePreparedEvent $event ) {
+	public function servicePrepared( ServiceWriterServicePreparedEvent $event ) {
 		$dockerContent = $event->getDockerContent();
 
 		$fileVersion = $event->getFileVersion();

--- a/app/Blueprint/PublishUrls/EventListener/PublishUrlsServiceWriterListener.php
+++ b/app/Blueprint/PublishUrls/EventListener/PublishUrlsServiceWriterListener.php
@@ -1,0 +1,48 @@
+<?php namespace Rancherize\Blueprint\PublisUrls\EventListener;
+
+use Rancherize\Blueprint\Healthcheck\HealthcheckExtraInformation\HealthcheckExtraInformation;
+use Rancherize\Blueprint\Healthcheck\HealthcheckYamlWriter\HealthcheckYamlWriter;
+use Rancherize\Blueprint\Infrastructure\Service\Events\ServiceWriterRancherServicePreparedEvent;
+use Rancherize\Blueprint\Infrastructure\Service\ExtraInformationNotFoundException;
+
+/**
+ * Class HealthcheckServiceWriterListener
+ * @package Rancherize\Blueprint\Healthcheck\EventListener
+ */
+class PublishUrlsServiceWriterListener {
+
+	/**
+	 * @var HealthcheckYamlWriter
+	 */
+	private $healthcheckYamlWriter;
+
+	/**
+	 * HealthcheckServiceWriterListener constructor.
+	 * @param HealthcheckYamlWriter $healthcheckYamlWriter
+	 */
+	public function __construct( HealthcheckYamlWriter $healthcheckYamlWriter) {
+		$this->healthcheckYamlWriter = $healthcheckYamlWriter;
+	}
+
+	/**
+	 * @param ServiceWriterRancherServicePreparedEvent $event
+	 */
+	public function rancherServicePrepared( ServiceWriterRancherServicePreparedEvent $event ) {
+		$rancherData = $event->getRancherContent();
+
+		$fileVersion = $event->getFileVersion();
+		$service = $event->getService();
+		try {
+			$extraInformation = $service->getExtraInformation(HealthcheckExtraInformation::IDENTIFIER);
+		} catch(ExtraInformationNotFoundException $e) {
+			return;
+		}
+
+		if( !$extraInformation instanceof HealthcheckExtraInformation )
+			return;
+
+		$this->healthcheckYamlWriter->write( $fileVersion, $extraInformation, $rancherData );
+
+		$event->setRancherContent($rancherData);
+	}
+}

--- a/app/Blueprint/PublishUrls/EventListener/PublishUrlsServiceWriterListener.php
+++ b/app/Blueprint/PublishUrls/EventListener/PublishUrlsServiceWriterListener.php
@@ -1,48 +1,47 @@
 <?php namespace Rancherize\Blueprint\PublisUrls\EventListener;
 
-use Rancherize\Blueprint\Healthcheck\HealthcheckExtraInformation\HealthcheckExtraInformation;
-use Rancherize\Blueprint\Healthcheck\HealthcheckYamlWriter\HealthcheckYamlWriter;
-use Rancherize\Blueprint\Infrastructure\Service\Events\ServiceWriterRancherServicePreparedEvent;
+use Rancherize\Blueprint\Infrastructure\Service\Events\ServiceWriterServicePreparedEvent;
 use Rancherize\Blueprint\Infrastructure\Service\ExtraInformationNotFoundException;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PublishUrlsYamlWriter;
 
 /**
  * Class HealthcheckServiceWriterListener
  * @package Rancherize\Blueprint\Healthcheck\EventListener
  */
 class PublishUrlsServiceWriterListener {
+	/**
+	 * @var PublishUrlsYamlWriter
+	 */
+	private $yamlWriter;
 
 	/**
-	 * @var HealthcheckYamlWriter
+	 * PublishUrlsServiceWriterListener constructor.
+	 * @param PublishUrlsYamlWriter $yamlWriter
 	 */
-	private $healthcheckYamlWriter;
-
-	/**
-	 * HealthcheckServiceWriterListener constructor.
-	 * @param HealthcheckYamlWriter $healthcheckYamlWriter
-	 */
-	public function __construct( HealthcheckYamlWriter $healthcheckYamlWriter) {
-		$this->healthcheckYamlWriter = $healthcheckYamlWriter;
+	public function __construct( PublishUrlsYamlWriter $yamlWriter ) {
+		$this->yamlWriter = $yamlWriter;
 	}
 
 	/**
-	 * @param ServiceWriterRancherServicePreparedEvent $event
+	 * @param ServiceWriterServicePreparedEvent $event
 	 */
-	public function rancherServicePrepared( ServiceWriterRancherServicePreparedEvent $event ) {
-		$rancherData = $event->getRancherContent();
+	public function dockerServicePrepared( ServiceWriterServicePreparedEvent $event ) {
+		$dockerContent = $event->getDockerContent();
 
 		$fileVersion = $event->getFileVersion();
 		$service = $event->getService();
 		try {
-			$extraInformation = $service->getExtraInformation(HealthcheckExtraInformation::IDENTIFIER);
+			$extraInformation = $service->getExtraInformation(PublishUrlsExtraInformation::IDENTIFIER );
 		} catch(ExtraInformationNotFoundException $e) {
 			return;
 		}
 
-		if( !$extraInformation instanceof HealthcheckExtraInformation )
+		if( !$extraInformation instanceof PublishUrlsExtraInformation )
 			return;
 
-		$this->healthcheckYamlWriter->write( $fileVersion, $extraInformation, $rancherData );
+		$this->yamlWriter->write( $fileVersion, $extraInformation, $dockerContent );
 
-		$event->setRancherContent($rancherData);
+		$event->setDockerContent($dockerContent);
 	}
 }

--- a/app/Blueprint/PublishUrls/PublishUrlsExtraInformation/PublishUrlsExtraInformation.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsExtraInformation/PublishUrlsExtraInformation.php
@@ -1,0 +1,55 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation;
+
+use Rancherize\Blueprint\Infrastructure\Service\ServiceExtraInformation;
+
+/**
+ * Class PublishUrlsExtraInformation
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation
+ */
+class PublishUrlsExtraInformation implements ServiceExtraInformation {
+
+	/**
+	 * @var int
+	 */
+	protected $port;
+
+	/**
+	 * @var
+	 */
+	protected $urls = [];
+
+	/**
+	 * @return mixed
+	 */
+	public function getIdentifier() {
+		return 'publish-urls';
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getPort(): int {
+		return $this->port;
+	}
+
+	/**
+	 * @param int $port
+	 */
+	public function setPort( int $port ) {
+		$this->port = $port;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getUrls() {
+		return $this->urls;
+	}
+
+	/**
+	 * @param mixed $urls
+	 */
+	public function setUrls( $urls ) {
+		$this->urls = $urls;
+	}
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsExtraInformation/PublishUrlsExtraInformation.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsExtraInformation/PublishUrlsExtraInformation.php
@@ -40,14 +40,14 @@ class PublishUrlsExtraInformation implements ServiceExtraInformation {
 	/**
 	 * @return int
 	 */
-	public function getPort(): int {
+	public function getPort() {
 		return $this->port;
 	}
 
 	/**
 	 * @param int $port
 	 */
-	public function setPort( int $port ) {
+	public function setPort( $port ) {
 		$this->port = $port;
 	}
 
@@ -75,21 +75,21 @@ class PublishUrlsExtraInformation implements ServiceExtraInformation {
 	/**
 	 * @param string $type
 	 */
-	public function setType( string $type ) {
+	public function setType( $type ) {
 		$this->type = $type;
 	}
 
 	/**
 	 * @return int
 	 */
-	public function getPriority(): int {
+	public function getPriority() {
 		return $this->priority;
 	}
 
 	/**
 	 * @param int $priority
 	 */
-	public function setPriority( int $priority ) {
+	public function setPriority( $priority ) {
 		$this->priority = $priority;
 	}
 }

--- a/app/Blueprint/PublishUrls/PublishUrlsExtraInformation/PublishUrlsExtraInformation.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsExtraInformation/PublishUrlsExtraInformation.php
@@ -8,6 +8,13 @@ use Rancherize\Blueprint\Infrastructure\Service\ServiceExtraInformation;
  */
 class PublishUrlsExtraInformation implements ServiceExtraInformation {
 
+	const IDENTIFIER = 'publish-urls';
+
+	/**
+	 * @var string
+	 */
+	protected $type;
+
 	/**
 	 * @var int
 	 */
@@ -17,6 +24,11 @@ class PublishUrlsExtraInformation implements ServiceExtraInformation {
 	 * @var
 	 */
 	protected $urls = [];
+
+	/**
+	 * @var int
+	 */
+	protected $priority;
 
 	/**
 	 * @return mixed
@@ -51,5 +63,33 @@ class PublishUrlsExtraInformation implements ServiceExtraInformation {
 	 */
 	public function setUrls( $urls ) {
 		$this->urls = $urls;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getType() {
+		return $this->type;
+	}
+
+	/**
+	 * @param string $type
+	 */
+	public function setType( string $type ) {
+		$this->type = $type;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getPriority(): int {
+		return $this->priority;
+	}
+
+	/**
+	 * @param int $priority
+	 */
+	public function setPriority( int $priority ) {
+		$this->priority = $priority;
 	}
 }

--- a/app/Blueprint/PublishUrls/PublishUrlsExtraInformation/PublishUrlsExtraInformation.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsExtraInformation/PublishUrlsExtraInformation.php
@@ -21,9 +21,14 @@ class PublishUrlsExtraInformation implements ServiceExtraInformation {
 	protected $port;
 
 	/**
-	 * @var
+	 * @var string
 	 */
-	protected $urls = [];
+	protected $url;
+
+	/**
+	 * @var array
+	 */
+	protected $pathes = [];
 
 	/**
 	 * @var int
@@ -52,17 +57,17 @@ class PublishUrlsExtraInformation implements ServiceExtraInformation {
 	}
 
 	/**
-	 * @return mixed
+	 * @return string
 	 */
-	public function getUrls() {
-		return $this->urls;
+	public function getUrl() {
+		return $this->url;
 	}
 
 	/**
-	 * @param mixed $urls
+	 * @param string $url
 	 */
-	public function setUrls( $urls ) {
-		$this->urls = $urls;
+	public function setUrl( $url ) {
+		$this->url = $url;
 	}
 
 	/**
@@ -91,5 +96,19 @@ class PublishUrlsExtraInformation implements ServiceExtraInformation {
 	 */
 	public function setPriority( $priority ) {
 		$this->priority = $priority;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getPathes(): array {
+		return $this->pathes;
+	}
+
+	/**
+	 * @param array $pathes
+	 */
+	public function setPathes( array $pathes ) {
+		$this->pathes = $pathes;
 	}
 }

--- a/app/Blueprint/PublishUrls/PublishUrlsIniter/PublishUrlsInitializer.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsIniter/PublishUrlsInitializer.php
@@ -1,0 +1,39 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsIniter;
+
+use Rancherize\Configuration\Configurable;
+use Rancherize\Configuration\PrefixConfigurableDecorator;
+use Rancherize\Configuration\Services\ConfigurationInitializer;
+
+/**
+ * Class PublishUrlsIniter
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsIniter
+ */
+class PublishUrlsInitializer {
+	/**
+	 * @var ConfigurationInitializer
+	 */
+	private $initializer;
+
+	/**
+	 * PublishUrlsInitializer constructor.
+	 * @param ConfigurationInitializer $initializer
+	 */
+	public function __construct( ConfigurationInitializer $initializer) {
+		$this->initializer = $initializer;
+	}
+
+	/**
+	 * @param Configurable $config
+	 * @param Configurable $setter
+	 */
+	public function init( Configurable $config, Configurable $setter ) {
+
+		$publishConfigurable = new PrefixConfigurableDecorator($config, 'publish.');
+		$publishSetterConfigurable = new PrefixConfigurableDecorator($setter, 'publish.');
+
+		$this->initializer->init($publishConfigurable, 'publish.enable', false, $publishSetterConfigurable);
+		$this->initializer->init($publishConfigurable, 'publish.url', 'https://www.example.com/path', $publishSetterConfigurable);
+
+	}
+
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsIniter/PublishUrlsInitializer.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsIniter/PublishUrlsInitializer.php
@@ -23,19 +23,19 @@ class PublishUrlsInitializer {
 	}
 
 	/**
-	 * @param Configurable $config
-	 * @param Configurable $setter
+	 * @param Configurable $environmentSetter
+	 * @param Configurable $projectSetter
 	 */
-	public function init( Configurable $config, Configurable $setter = null ) {
+	public function init( Configurable $environmentSetter, Configurable $projectSetter = null ) {
 
-		if($setter === null)
-			$setter = $config;
+		if($projectSetter === null)
+			$projectSetter = $environmentSetter;
 
-		$publishConfigurable = new PrefixConfigurableDecorator($config, 'publish.');
-		$publishSetterConfigurable = new PrefixConfigurableDecorator($setter, 'publish.');
+		$publishEnvironmentConfigurable = new PrefixConfigurableDecorator($environmentSetter, 'publish.');
+		$publishProjectConfigurable = new PrefixConfigurableDecorator($projectSetter, 'publish.');
 
-		$this->initializer->init($publishConfigurable, 'publish.enable', false, $publishSetterConfigurable);
-		$this->initializer->init($publishConfigurable, 'publish.url', 'https://www.example.com/path', $publishSetterConfigurable);
+		$this->initializer->init($publishEnvironmentConfigurable, 'publish.enable', false, $publishProjectConfigurable);
+		$this->initializer->init($publishEnvironmentConfigurable, 'publish.url', 'https://www.example.com/');
 
 	}
 

--- a/app/Blueprint/PublishUrls/PublishUrlsIniter/PublishUrlsInitializer.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsIniter/PublishUrlsInitializer.php
@@ -26,7 +26,7 @@ class PublishUrlsInitializer {
 	 * @param Configurable $config
 	 * @param Configurable $setter
 	 */
-	public function init( Configurable $config, Configurable $setter ) {
+	public function init( Configurable $config, Configurable $setter = null ) {
 
 		$publishConfigurable = new PrefixConfigurableDecorator($config, 'publish.');
 		$publishSetterConfigurable = new PrefixConfigurableDecorator($setter, 'publish.');

--- a/app/Blueprint/PublishUrls/PublishUrlsIniter/PublishUrlsInitializer.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsIniter/PublishUrlsInitializer.php
@@ -34,8 +34,8 @@ class PublishUrlsInitializer {
 		$publishEnvironmentConfigurable = new PrefixConfigurableDecorator($environmentSetter, 'publish.');
 		$publishProjectConfigurable = new PrefixConfigurableDecorator($projectSetter, 'publish.');
 
-		$this->initializer->init($publishEnvironmentConfigurable, 'publish.enable', false, $publishProjectConfigurable);
-		$this->initializer->init($publishEnvironmentConfigurable, 'publish.url', 'https://www.example.com/');
+		$this->initializer->init($publishEnvironmentConfigurable, 'enable', false, $publishProjectConfigurable);
+		$this->initializer->init($publishEnvironmentConfigurable, 'url', 'https://www.example.com/');
 
 	}
 

--- a/app/Blueprint/PublishUrls/PublishUrlsIniter/PublishUrlsInitializer.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsIniter/PublishUrlsInitializer.php
@@ -28,6 +28,9 @@ class PublishUrlsInitializer {
 	 */
 	public function init( Configurable $config, Configurable $setter = null ) {
 
+		if($setter === null)
+			$setter = $config;
+
 		$publishConfigurable = new PrefixConfigurableDecorator($config, 'publish.');
 		$publishSetterConfigurable = new PrefixConfigurableDecorator($setter, 'publish.');
 

--- a/app/Blueprint/PublishUrls/PublishUrlsParser/PublishUrlsParser.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsParser/PublishUrlsParser.php
@@ -1,0 +1,42 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsParser;
+
+use Rancherize\Blueprint\Infrastructure\Service\Service;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+use Rancherize\Configuration\Configuration;
+use Rancherize\Configuration\PrefixConfigurationDecorator;
+
+/**
+ * Class PublishUrlsParser
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsParser
+ *
+ * Reads urls to be published from the configuration
+ */
+class PublishUrlsParser {
+
+	/**
+	 * @param Service $service
+	 * @param Configuration $configuration
+	 */
+	public function parseToService( Service $service, Configuration $configuration ) {
+
+		$publishUrlsConfig = new PrefixConfigurationDecorator($configuration, 'publish-urls.');
+
+		$publishUrlsEnabled = $publishUrlsConfig->get( 'enable', true );
+		if( !$publishUrlsEnabled )
+			return;
+
+		$publishUrlsInformation = new PublishUrlsExtraInformation();
+		$publishUrlsInformation->setPort( $publishUrlsConfig->get('port', 80) );
+		$publishUrlsInformation->setType( $publishUrlsConfig->get('type', 'traefik') );
+		$publishUrlsInformation->setPriority( $publishUrlsConfig->get('priority', 5) );
+
+		$urls = $publishUrlsConfig->get( 'urls', [] );
+		if( empty($urls) )
+			return;
+
+		$publishUrlsInformation->setUrls( $urls );
+
+		$service->addExtraInformation( $publishUrlsInformation );
+	}
+
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsParser/PublishUrlsParser.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsParser/PublishUrlsParser.php
@@ -19,7 +19,7 @@ class PublishUrlsParser {
 	 */
 	public function parseToService( Service $service, Configuration $configuration ) {
 
-		$publishUrlsConfig = new PrefixConfigurationDecorator($configuration, 'publish-urls.');
+		$publishUrlsConfig = new PrefixConfigurationDecorator($configuration, 'publish.');
 
 		$publishUrlsEnabled = $publishUrlsConfig->get( 'enable', true );
 		if( !$publishUrlsEnabled )

--- a/app/Blueprint/PublishUrls/PublishUrlsParser/PublishUrlsParser.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsParser/PublishUrlsParser.php
@@ -28,13 +28,19 @@ class PublishUrlsParser {
 		$publishUrlsInformation = new PublishUrlsExtraInformation();
 		$publishUrlsInformation->setPort( $publishUrlsConfig->get('port', 80) );
 		$publishUrlsInformation->setType( $publishUrlsConfig->get('type', 'traefik') );
-		$publishUrlsInformation->setPriority( $publishUrlsConfig->get('priority', 5) );
 
-		$urls = $publishUrlsConfig->get( 'urls', [] );
-		if( empty($urls) )
+		$url = $publishUrlsConfig->get( 'url', '' );
+		if( empty($url) )
 			return;
+		$publishUrlsInformation->setUrl( $url );
 
-		$publishUrlsInformation->setUrls( $urls );
+		$pathes = $publishUrlsConfig->get( 'pathes', [] );
+		$publishUrlsInformation->setPathes($pathes);
+
+		$defaultPriority = 5;
+		if( !empty($pathes) )
+			$defaultPriority = 10;
+		$publishUrlsInformation->setPriority( $publishUrlsConfig->get('priority', $defaultPriority) );
 
 		$service->addExtraInformation( $publishUrlsInformation );
 	}

--- a/app/Blueprint/PublishUrls/PublishUrlsProvider.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsProvider.php
@@ -1,0 +1,30 @@
+<?php namespace Rancherize\Blueprint\PublishUrls;
+
+use Rancherize\Plugin\Provider;
+use Rancherize\Plugin\ProviderTrait;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * Class PublishUrlsProvider
+ * @package Rancherize\Blueprint\PublishUrls
+ */
+class PublishUrlsProvider implements Provider {
+
+	use ProviderTrait;
+
+	/**
+	 */
+	public function register() {
+	}
+
+	/**
+	 */
+	public function boot() {
+		/**
+		 * @var EventDispatcher $event
+		 */
+		$event = $this->container['event'];
+		$listener = $this->container['publish-urls-service-writer-listener'];
+		$event->addListener(ServiceWriterRancherServicePreparedEvent::NAME, [$listener, 'rancherServicePrepared']);
+	}
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsProvider.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsProvider.php
@@ -1,6 +1,8 @@
 <?php namespace Rancherize\Blueprint\PublishUrls;
 
 use Rancherize\Blueprint\Infrastructure\Service\Events\ServiceWriterServicePreparedEvent;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsParser\PublishUrlsParser;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PublishUrlsYamlWriter;
 use Rancherize\Blueprint\PublisUrls\EventListener\PublishUrlsServiceWriterListener;
 use Rancherize\Plugin\Provider;
 use Rancherize\Plugin\ProviderTrait;
@@ -17,8 +19,16 @@ class PublishUrlsProvider implements Provider {
 	/**
 	 */
 	public function register() {
+		$this->container['publish-urls-yaml-writer'] = function($c) {
+			return new PublishUrlsYamlWriter();
+		};
+
 		$this->container['publish-urls-service-writer-listener'] = function($c) {
-			return new PublishUrlsServiceWriterListener();
+			return new PublishUrlsServiceWriterListener( $c['publish-urls-yaml-writer'] );
+		};
+
+		$this->container['publish-urls-parser'] = function($c) {
+			return new PublishUrlsParser();
 		};
 	}
 

--- a/app/Blueprint/PublishUrls/PublishUrlsProvider.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsProvider.php
@@ -1,5 +1,7 @@
 <?php namespace Rancherize\Blueprint\PublishUrls;
 
+use Rancherize\Blueprint\Infrastructure\Service\Events\ServiceWriterServicePreparedEvent;
+use Rancherize\Blueprint\PublisUrls\EventListener\PublishUrlsServiceWriterListener;
 use Rancherize\Plugin\Provider;
 use Rancherize\Plugin\ProviderTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -15,6 +17,9 @@ class PublishUrlsProvider implements Provider {
 	/**
 	 */
 	public function register() {
+		$this->container['publish-urls-service-writer-listener'] = function($c) {
+			return new PublishUrlsServiceWriterListener();
+		};
 	}
 
 	/**
@@ -25,6 +30,6 @@ class PublishUrlsProvider implements Provider {
 		 */
 		$event = $this->container['event'];
 		$listener = $this->container['publish-urls-service-writer-listener'];
-		$event->addListener(ServiceWriterRancherServicePreparedEvent::NAME, [$listener, 'rancherServicePrepared']);
+		$event->addListener(ServiceWriterServicePreparedEvent::NAME, [$listener, 'servicePrepared']);
 	}
 }

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/PartWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/PartWriter.php
@@ -1,0 +1,17 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\Traefik\V2;
+
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+
+/**
+ * Interface PartWriter
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\Traefik\V2
+ */
+interface PartWriter {
+
+	/**
+	 * @param PublishUrlsExtraInformation $extraInformation
+	 * @param array $dockerService
+	 * @return mixed
+	 */
+	function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService );
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/PartWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/PartWriter.php
@@ -11,7 +11,6 @@ interface PartWriter {
 	/**
 	 * @param PublishUrlsExtraInformation $extraInformation
 	 * @param array $dockerService
-	 * @return mixed
 	 */
 	function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService );
 }

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikAliasWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikAliasWriter.php
@@ -17,7 +17,7 @@ class TraefikAliasWriter implements PartWriter {
 		$url = $extraInformation->getUrl();
 		$fullPath = parse_url($url, PHP_URL_HOST);
 		$matches = [];
-		if( preg_match('/[^\\.]/', $fullPath, $matches) != 1 )
+		if( preg_match('/[^\\.]*/', $fullPath, $matches) != 1 )
 			return;
 		$hostname = $matches[0];
 

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikAliasWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikAliasWriter.php
@@ -12,12 +12,14 @@ class TraefikAliasWriter implements PartWriter {
 	/**
 	 * @param PublishUrlsExtraInformation $extraInformation
 	 * @param array $dockerService
-	 * @return mixed
 	 */
 	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
 		$url = $extraInformation->getUrl();
 		$fullPath = parse_url($url, PHP_URL_HOST);
-		$hostname = preg_match('[^\.]', $fullPath);
+		$matches = [];
+		if( preg_match('/[^\\.]/', $fullPath, $matches) != 1 )
+			return;
+		$hostname = $matches[0];
 
 		$dockerService['labels']['traefik.alias'] = $hostname;
 	}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikAliasWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikAliasWriter.php
@@ -15,9 +15,8 @@ class TraefikAliasWriter implements PartWriter {
 	 * @return mixed
 	 */
 	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
-		$urls = $extraInformation->getUrls();
-		$firstUrl = reset($urls);
-		$fullPath = parse_url($firstUrl, PHP_URL_HOST);
+		$url = $extraInformation->getUrl();
+		$fullPath = parse_url($url, PHP_URL_HOST);
 		$hostname = preg_match('[^\.]', $fullPath);
 
 		$dockerService['labels']['traefik.alias'] = $hostname;

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikAliasWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikAliasWriter.php
@@ -1,0 +1,25 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik;
+
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\Traefik\V2\PartWriter;
+
+/**
+ * Class TraefikAliasWriter
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik
+ */
+class TraefikAliasWriter implements PartWriter {
+
+	/**
+	 * @param PublishUrlsExtraInformation $extraInformation
+	 * @param array $dockerService
+	 * @return mixed
+	 */
+	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
+		$urls = $extraInformation->getUrls();
+		$firstUrl = reset($urls);
+		$fullPath = parse_url($firstUrl, PHP_URL_HOST);
+		$hostname = preg_match('[^\.]', $fullPath);
+
+		$dockerService['labels']['traefik.alias'] = $hostname;
+	}
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
@@ -15,9 +15,8 @@ class TraefikDomainWriter implements PartWriter {
 	 * @return mixed
 	 */
 	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
-		$urls = $extraInformation->getUrls();
-		$firstUrl = reset($urls);
-		$fullPath = parse_url($firstUrl, PHP_URL_HOST);
+		$url = $extraInformation->getUrl();
+		$fullPath = parse_url($url, PHP_URL_HOST);
 		$hostname = preg_match('[^\.]', $fullPath);
 		$domainName = substr($fullPath, count($hostname) + 2);
 

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
@@ -1,0 +1,26 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik;
+
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\Traefik\V2\PartWriter;
+
+/**
+ * Class TraefikDomainWriter
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik
+ */
+class TraefikDomainWriter implements PartWriter {
+
+	/**
+	 * @param PublishUrlsExtraInformation $extraInformation
+	 * @param array $dockerService
+	 * @return mixed
+	 */
+	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
+		$urls = $extraInformation->getUrls();
+		$firstUrl = reset($urls);
+		$fullPath = parse_url($firstUrl, PHP_URL_HOST);
+		$hostname = preg_match('[^\.]', $fullPath);
+		$domainName = substr($fullPath, count($hostname) + 2);
+
+		$dockerService['labels']['traefik.domain'] = $domainName;
+	}
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
@@ -22,7 +22,7 @@ class TraefikDomainWriter implements PartWriter {
 			return;
 		$hostname = $matches[0];
 
-		$domainName = substr($fullPath, count($hostname) + 2);
+		$domainName = substr($fullPath, strlen($hostname) + 2);
 
 		$dockerService['labels']['traefik.domain'] = $domainName;
 	}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
@@ -22,7 +22,7 @@ class TraefikDomainWriter implements PartWriter {
 			return;
 		$hostname = $matches[0];
 
-		$domainName = substr($fullPath, strlen($hostname) + 2);
+		$domainName = substr($fullPath, strlen($hostname) + 1);
 
 		$dockerService['labels']['traefik.domain'] = $domainName;
 	}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
@@ -12,12 +12,16 @@ class TraefikDomainWriter implements PartWriter {
 	/**
 	 * @param PublishUrlsExtraInformation $extraInformation
 	 * @param array $dockerService
-	 * @return mixed
 	 */
 	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
 		$url = $extraInformation->getUrl();
 		$fullPath = parse_url($url, PHP_URL_HOST);
-		$hostname = preg_match('[^\.]', $fullPath);
+
+		$matches = [];
+		if( preg_match('/[^\.]/', $fullPath, $matches) !== 1 )
+			return;
+		$hostname = $matches[0];
+
 		$domainName = substr($fullPath, count($hostname) + 2);
 
 		$dockerService['labels']['traefik.domain'] = $domainName;

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikDomainWriter.php
@@ -18,7 +18,7 @@ class TraefikDomainWriter implements PartWriter {
 		$fullPath = parse_url($url, PHP_URL_HOST);
 
 		$matches = [];
-		if( preg_match('/[^\.]/', $fullPath, $matches) !== 1 )
+		if( preg_match('/[^\.]*/', $fullPath, $matches) !== 1 )
 			return;
 		$hostname = $matches[0];
 

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikEnableWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikEnableWriter.php
@@ -1,0 +1,20 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik;
+
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\Traefik\V2\PartWriter;
+
+/**
+ * Class TraefikEnableWriter
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik
+ */
+class TraefikEnableWriter implements PartWriter {
+
+	/**
+	 * @param PublishUrlsExtraInformation $extraInformation
+	 * @param array $dockerService
+	 * @return mixed
+	 */
+	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
+		$dockerService['labels']['traefik.enable'] = 'true';
+	}
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikEnableWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikEnableWriter.php
@@ -12,7 +12,6 @@ class TraefikEnableWriter implements PartWriter {
 	/**
 	 * @param PublishUrlsExtraInformation $extraInformation
 	 * @param array $dockerService
-	 * @return mixed
 	 */
 	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
 		$dockerService['labels']['traefik.enable'] = 'true';

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPathesWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPathesWriter.php
@@ -12,7 +12,6 @@ class TraefikPathesWriter implements PartWriter {
 	/**
 	 * @param PublishUrlsExtraInformation $extraInformation
 	 * @param array $dockerService
-	 * @return mixed
 	 */
 	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
 		$pathes = $extraInformation->getPathes();

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPathesWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPathesWriter.php
@@ -1,0 +1,35 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik;
+
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\Traefik\V2\PartWriter;
+
+/**
+ * Class TraefikPathesWriter
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik
+ */
+class TraefikPathesWriter implements PartWriter {
+
+	/**
+	 * @param PublishUrlsExtraInformation $extraInformation
+	 * @param array $dockerService
+	 * @return mixed
+	 */
+	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
+		$urls = $extraInformation->getUrls();
+
+		$pathes = [];
+		foreach ($urls as $url) {
+			$path = parse_url($url, PHP_URL_PATH);
+
+			if( empty($path) || $path === '/' )
+				continue;
+
+			$pathes[] = $path;
+		}
+
+		if( empty($pathes) )
+			return;
+
+		$dockerService['labels']['traefik.path.prefix'] = implode(',', $pathes);
+	}
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPathesWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPathesWriter.php
@@ -15,17 +15,7 @@ class TraefikPathesWriter implements PartWriter {
 	 * @return mixed
 	 */
 	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
-		$urls = $extraInformation->getUrls();
-
-		$pathes = [];
-		foreach ($urls as $url) {
-			$path = parse_url($url, PHP_URL_PATH);
-
-			if( empty($path) || $path === '/' )
-				continue;
-
-			$pathes[] = $path;
-		}
+		$pathes = $extraInformation->getPathes();
 
 		if( empty($pathes) )
 			return;

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPortWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPortWriter.php
@@ -1,0 +1,22 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik;
+
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\Traefik\V2\PartWriter;
+
+/**
+ * Class TraefikPortWriter
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik
+ */
+class TraefikPortWriter implements PartWriter {
+
+	/**
+	 * @param PublishUrlsExtraInformation $extraInformation
+	 * @param array $dockerService
+	 * @return mixed
+	 */
+	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
+		$port = $extraInformation->getPort();
+
+		$dockerService['labels']['traefik.port'] = $port;
+	}
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPortWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPortWriter.php
@@ -12,7 +12,6 @@ class TraefikPortWriter implements PartWriter {
 	/**
 	 * @param PublishUrlsExtraInformation $extraInformation
 	 * @param array $dockerService
-	 * @return mixed
 	 */
 	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
 		$port = $extraInformation->getPort();

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPriorityWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPriorityWriter.php
@@ -1,0 +1,22 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik;
+
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\Traefik\V2\PartWriter;
+
+/**
+ * Class TraefikPriorityWriter
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik
+ */
+class TraefikPriorityWriter implements PartWriter {
+
+	/**
+	 * @param PublishUrlsExtraInformation $extraInformation
+	 * @param array $dockerService
+	 * @return mixed
+	 */
+	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
+		$priority = $extraInformation->getPriority();
+
+		$dockerService['labels']['traefik.priority'] = $priority;
+	}
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPriorityWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PartWriter/Traefik/TraefikPriorityWriter.php
@@ -12,7 +12,6 @@ class TraefikPriorityWriter implements PartWriter {
 	/**
 	 * @param PublishUrlsExtraInformation $extraInformation
 	 * @param array $dockerService
-	 * @return mixed
 	 */
 	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
 		$priority = $extraInformation->getPriority();

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PublishUrlsYamlWithPartWriters.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PublishUrlsYamlWithPartWriters.php
@@ -1,0 +1,33 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter;
+
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\Traefik\V2\PartWriter;
+
+/**
+ * Class PublishUrlsYamlWithPartWriters
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter
+ */
+class PublishUrlsYamlWithPartWriters implements PublishUrlsYamlWriterVersion {
+
+	/**
+	 * @var PartWriter[]
+	 */
+	protected $partWriters;
+
+	/**
+	 * @param PartWriter $partWriter
+	 */
+	protected function addPartWriter(PartWriter $partWriter) {
+		$this->partWriters[] = $partWriter;
+	}
+
+	/**
+	 * @param PublishUrlsExtraInformation $extraInformation
+	 * @param array $dockerService
+	 */
+	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
+
+		foreach($this->partWriters as $partWriter)
+			$partWriter->write($extraInformation, $dockerService);
+	}
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PublishUrlsYamlWriter.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PublishUrlsYamlWriter.php
@@ -1,0 +1,60 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+
+/**
+ * Class PublishUrlsYamlWriter
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter
+ */
+class PublishUrlsYamlWriter {
+
+	/**
+	 * @var string
+	 */
+	protected $defaultType = 'traefik';
+
+	/**
+	 * @var int
+	 */
+	protected  $defaultVersion = 2;
+
+	/**
+	 * @var PublishUrlsYamlWriterVersion[][]
+	 */
+	protected $versions = [
+		'traefik' => [
+
+		],
+	];
+
+	public function __construct() {
+		$this->versions['traefik'][2] = new V2TraefikPublishUrlsYamlWriterVersion();
+	}
+
+	/**
+	 * @param $version
+	 * @param PublishUrlsExtraInformation $extraInformation
+	 * @param array $dockerService
+	 */
+	public function write( $version, PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
+		$type = $extraInformation->getType();
+		if($type === null)
+			$type = $this->defaultType;
+
+		$writerTypeExists = array_key_exists( $type, $this->versions );
+		if($type !== null && !$writerTypeExists )
+			$type = $this->defaultType;
+
+		if( !array_key_exists($version, $this->versions[$type]) ) {
+			/**
+			 * TODO: Warning
+			 */
+			$version = $this->defaultVersion;
+		}
+
+
+		$version = $this->versions[$type][$version];
+
+		$version->write($extraInformation, $dockerService);
+	}
+
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PublishUrlsYamlWriterVersion.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/PublishUrlsYamlWriterVersion.php
@@ -1,0 +1,16 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter;
+
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+
+/**
+ * Interface PublishUrlsYamlWriterVersion
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter
+ */
+interface PublishUrlsYamlWriterVersion {
+
+	/**
+	 * @param PublishUrlsExtraInformation $extraInformation
+	 * @param array $dockerService
+	 */
+	function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService );
+}

--- a/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/Traefik/V2/V2TraefikPublishUrlsYamlWriterVersion.php
+++ b/app/Blueprint/PublishUrls/PublishUrlsYamlWriter/Traefik/V2/V2TraefikPublishUrlsYamlWriterVersion.php
@@ -1,0 +1,36 @@
+<?php namespace Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter;
+
+use Rancherize\Blueprint\PublishUrls\PublishUrlsExtraInformation\PublishUrlsExtraInformation;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik\TraefikAliasWriter;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik\TraefikDomainWriter;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik\TraefikEnableWriter;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik\TraefikPathesWriter;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter\PartWriter\Traefik\TraefikPriorityWriter;
+
+/**
+ * Class V2TraefikPublishUrlsYamlWriterVersion
+ * @package Rancherize\Blueprint\PublishUrls\PublishUrlsYamlWriter
+ */
+class V2TraefikPublishUrlsYamlWriterVersion extends PublishUrlsYamlWithPartWriters {
+
+	public function __construct() {
+		$this->addPartWriter( new TraefikEnableWriter() );
+		$this->addPartWriter( new TraefikAliasWriter() );
+		$this->addPartWriter( new TraefikDomainWriter() );
+		$this->addPartWriter( new TraefikPathesWriter() );
+		$this->addPartWriter( new TraefikPriorityWriter() );
+	}
+
+	/**
+	 * @param PublishUrlsExtraInformation $extraInformation
+	 * @param array $dockerService
+	 */
+	public function write( PublishUrlsExtraInformation $extraInformation, array &$dockerService ) {
+
+		if( !array_key_exists('labels', $dockerService) )
+			$dockerService['labels'] = [];
+
+		parent::write($extraInformation, $dockerService);
+
+	}
+}

--- a/app/Blueprint/PublishUrls/README.md
+++ b/app/Blueprint/PublishUrls/README.md
@@ -1,5 +1,11 @@
 # PublishUrls
-Takes care of setting docker 
+Takes care of setting docker environment variables / labels to request the publish of a given domain(and path) to the
+rancher service spawned by rancherize.  
+These settings have to be picked up by service discovery. The `traefik` rancher load balancer does this on its own, based
+on labels.
+
+# List of implementations
+- traefik
 
 ## Use case
 The rancher traefik loadbalancer publishes service ports based on a list of labels:

--- a/app/Blueprint/PublishUrls/README.md
+++ b/app/Blueprint/PublishUrls/README.md
@@ -1,0 +1,27 @@
+# PublishUrls
+Takes care of setting docker 
+
+## Use case
+The rancher traefik loadbalancer publishes service ports based on a list of labels:
+- traefik.enable
+- traefik.domain
+- traefik.alias
+- traefik.path
+- traefik.path.prefix
+- traefik.priority
+
+Setting
+```json
+{
+	"publish-urls": {
+		"enable": true,
+		"urls":[
+			"https://www.example.com/sitemap.xml",
+			"https://www.example.com/sitemaps/"
+		]
+	}
+}
+```
+Will set the traefik labels to balance the pathes `sitemap.xml,/sitemaps/` on `www.example.com` to the service.
+The protocol is currently ignored.  
+Since no port is given port 80 is assumed

--- a/app/Blueprint/Webserver/WebserverBlueprint.php
+++ b/app/Blueprint/Webserver/WebserverBlueprint.php
@@ -14,6 +14,8 @@ use Rancherize\Blueprint\Infrastructure\Service\Services\DatabaseService;
 use Rancherize\Blueprint\Infrastructure\Service\Services\LaravelQueueWorker;
 use Rancherize\Blueprint\Infrastructure\Service\Services\PmaService;
 use Rancherize\Blueprint\Infrastructure\Service\Services\RedisService;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsIniter\PublishUrlsInitializer;
+use Rancherize\Blueprint\PublishUrls\PublishUrlsParser\PublishUrlsParser;
 use Rancherize\Blueprint\Validation\Exceptions\ValidationFailedException;
 use Rancherize\Blueprint\Validation\Traits\HasValidatorTrait;
 use Rancherize\Configuration\Configurable;
@@ -89,7 +91,10 @@ class WebserverBlueprint implements Blueprint {
 			$initializer->init($fallbackConfigurable, 'rancher.stack', 'Project');
 
 			$healthcheckInit = new HealthcheckInitService($initializer);
-			$healthcheckInit->init($projectConfigurable);
+			$healthcheckInit->init($fallbackConfigurable);
+
+			$publishUrlsInit = new PublishUrlsInitializer($initializer);
+			$publishUrlsInit->init($fallbackConfigurable);
 		}
 
 		$initializer->init($fallbackConfigurable, 'php', "7.0");
@@ -174,6 +179,12 @@ class WebserverBlueprint implements Blueprint {
 		 */
 		$healthcheckParser = container('healthcheck-parser');
 		$healthcheckParser->parseToService( $serverService, $config );
+
+		/**
+		 * @var PublishUrlsParser $publishUrlsParser
+		 */
+		$publishUrlsParser = container('publish-urls-parser');
+		$publishUrlsParser->parseToService( $serverService, $config );
 
         $infrastructure->addService($serverService);
 

--- a/app/lists/plugins.php
+++ b/app/lists/plugins.php
@@ -2,5 +2,5 @@
 
 return [
 	'Rancherize\Blueprint\Healthcheck\HealthcheckProvider',
-	'Rancherize\Blueprint\PublishUrls\PrublishUrlsProvider',
+	'Rancherize\Blueprint\PublishUrls\PublishUrlsProvider',
 ];

--- a/app/lists/plugins.php
+++ b/app/lists/plugins.php
@@ -2,4 +2,5 @@
 
 return [
 	'Rancherize\Blueprint\Healthcheck\HealthcheckProvider',
+	'Rancherize\Blueprint\PublishUrls\PrublishUrlsProvider',
 ];


### PR DESCRIPTION
Added uniform syntax to publish urls to loadbalancers / service discovery.
Implemented to use Rancher-Traefik by default, which adds certain labels to the service.