### PR TITLE
php7.3-v4.2 was added to queue worker image version

### DIFF
--- a/app/Blueprint/Infrastructure/Service/Services/LaravelQueueWorker.php
+++ b/app/Blueprint/Infrastructure/Service/Services/LaravelQueueWorker.php
@@ -16,6 +16,7 @@ class LaravelQueueWorker extends Service
         'php7.2-v3.0',
         'php7.3-v4.0',
         'php7.3-v4.1',
+        'php7.3-v4.2',
         'latest',
     ];
 

--- a/app/Blueprint/Webserver/README.md
+++ b/app/Blueprint/Webserver/README.md
@@ -60,7 +60,7 @@ This blueprint creates infrastructures to support apps using php7.
 |`php.upload-file-limit`| `2M` | PHP post_max_size option |
 |`php.default-timezone`| `UTC` | PHP date.timezone option |
 |`queues`| [] | Add Laravel Queue Worker, providing their name and connection in `name` and `connection`. Example: `"queues":[{"connection": "redis","name": "default","horizon":false,memory-limit":512}],` |
-|`queue-image-version`| `php7.0-v1.0` | Which docker image version do you need: (default: `php7.0-v1.0`; also `php7.1-v2.0`, `php7.2-v3.0`, `php7.3-v4.1` and `latest` are [valid](https://cloud.docker.com/u/ipunktbs/repository/docker/ipunktbs/laravel-queue-worker/tags) right now) |
+|`queue-image-version`| `php7.0-v1.0` | Which docker image version do you need: (default: `php7.0-v1.0`; also `php7.1-v2.0`, `php7.2-v3.0`, `php7.3-v4.2` and `latest` are [valid](https://cloud.docker.com/u/ipunktbs/repository/docker/ipunktbs/laravel-queue-worker/tags) right now) |
 |`add-redis`| false | Add a Redis server and link it to the main app, providing its name and port in `REDIS_HOST` and `REDIS_PORT` |
 
 ##### Queue Worker


### PR DESCRIPTION
We have a brand new version of the queue worker image `php7.3-v4.2` with bcmath (php extension) support and a watchdog for the supervisord programs.

bcmath is necessary to fully support Laravel Telescope on the queue worker side.